### PR TITLE
Fix AbsoluteSize/Position race condition positioning slider dragger incorrectly

### DIFF
--- a/src/GuiLib/Classes/Slider.lua
+++ b/src/GuiLib/Classes/Slider.lua
@@ -142,13 +142,13 @@ function init(self)
 	
 	local last = -1
 	local bPos, bSize
+	local initialBoundsCalculated = false
 	local function updateBounds()
 		bPos, bSize = getBounds(self)
 		background.Size = setUdim2(bSize / frame.AbsoluteSize[axis], 1)
 		last = -1
 	end
 	
-	updateBounds()
 	maid:Mark(frame:GetPropertyChangedSignal("AbsoluteSize"):Connect(updateBounds))
 	maid:Mark(frame:GetPropertyChangedSignal("AbsolutePosition"):Connect(updateBounds))
 	maid:Mark(frame:GetPropertyChangedSignal("Parent"):Connect(updateBounds))
@@ -193,6 +193,11 @@ function init(self)
 	
 	-- position the slider
 	maid:Mark(RUNSERVICE.RenderStepped:Connect(function(dt)
+		if not initialBoundsCalculated then
+			updateBounds()
+			initialBoundsCalculated = true
+		end
+
 		if (xboxSelected) then
 			local t = tick()
 			if (self.Interval <= 0) then

--- a/src/GuiLib/Classes/Slider.lua
+++ b/src/GuiLib/Classes/Slider.lua
@@ -206,7 +206,9 @@ function init(self)
 		spring:Update(dt)
 		local x = spring.x
 		if (x ~= last) then
-			local scalePos = (bPos + (x * bSize) - frame.AbsolutePosition[axis]) / frame.AbsoluteSize[axis]
+			local aPos = frame.AbsolutePosition[axis] -- AbsolutePosition and AbsoluteSize can return wrong values on the first frame 
+      local aSize = frame.AbsoluteSize[axis] -- Storing these in variables resolves this race condition somehow
+      local scalePos = (bPos + (x * bSize) - aPos) / aSize
 			dragger.Position = setUdim2(scalePos, 0.5)
 			self._ChangedBind:Fire(self:Get())
 			last = x

--- a/src/GuiLib/Classes/Slider.lua
+++ b/src/GuiLib/Classes/Slider.lua
@@ -194,6 +194,7 @@ function init(self)
 	-- position the slider
 	maid:Mark(RUNSERVICE.RenderStepped:Connect(function(dt)
 		if not initialBoundsCalculated then
+			-- update on first rendered frame to make sure absolute sizes are correct
 			updateBounds()
 			initialBoundsCalculated = true
 		end
@@ -211,8 +212,8 @@ function init(self)
 		spring:Update(dt)
 		local x = spring.x
 		if (x ~= last) then
-			local aPos = frame.AbsolutePosition[axis] -- AbsolutePosition and AbsoluteSize can return wrong values on the first frame 
-			local aSize = frame.AbsoluteSize[axis] -- Storing these in variables resolves this race condition somehow
+			local aPos = frame.AbsolutePosition[axis]
+			local aSize = frame.AbsoluteSize[axis]
 			local scalePos = (bPos + (x * bSize) - aPos) / aSize
 			dragger.Position = setUdim2(scalePos, 0.5)
 			self._ChangedBind:Fire(self:Get())

--- a/src/GuiLib/Classes/Slider.lua
+++ b/src/GuiLib/Classes/Slider.lua
@@ -17,7 +17,7 @@ Properties:
 	Frame [instance]
 		> The container frame for the slider. Can be used for positioning and resizing.
 	Interval [number] [0, 1]
- 		> Set this to force an interval step on the slider. For example if you only wanted steps of 1/10th then you'd write
+		> Set this to force an interval step on the slider. For example if you only wanted steps of 1/10th then you'd write
 		> Slider.Interval = 0.1
 	IsActive [boolean]
 		> When true the slider can be interacted with by the user, when false its values can only be set by the developer.
@@ -207,8 +207,8 @@ function init(self)
 		local x = spring.x
 		if (x ~= last) then
 			local aPos = frame.AbsolutePosition[axis] -- AbsolutePosition and AbsoluteSize can return wrong values on the first frame 
-      local aSize = frame.AbsoluteSize[axis] -- Storing these in variables resolves this race condition somehow
-      local scalePos = (bPos + (x * bSize) - aPos) / aSize
+			local aSize = frame.AbsoluteSize[axis] -- Storing these in variables resolves this race condition somehow
+			local scalePos = (bPos + (x * bSize) - aPos) / aSize
 			dragger.Position = setUdim2(scalePos, 0.5)
 			self._ChangedBind:Fire(self:Get())
 			last = x


### PR DESCRIPTION
Under certain circumstances it's possible for the dragger on the slider component to be positioned incorrectly (off the bar) the first time the slider is instantiated and parented.
Note the missing dragger in the images below:

![image](https://user-images.githubusercontent.com/26800119/104505393-6b1f9d00-55a9-11eb-92d5-4687fb3d3057.png) 
![image](https://user-images.githubusercontent.com/26800119/104508216-842a4d00-55ad-11eb-9ec8-2e4e43cd9b00.png)

[GuiLib_SliderBug.zip](https://github.com/EgoMoose/Rbx-Gui-Library/files/5810970/GuiLib_SliderBug.zip)

This is due to AbsolutePosition/Size returning incorrect values when used too early on an element within a GUI that is not parented yet, any delay(?) at all, even simply reading the properties in the RenderStepped binding before using them seems to resolve the issue. Retrieving these properties and storing them in variables before using them also appears to fully solve this issue somehow, despite how they should be incorrect at the time this assignment happens. Since this appears very sensitive to engine implementation details, it's possible that for very complex GUI layouts this solution might not introduce sufficient delay to always prevent this from happening.

I'm not sure if this is an acceptable fix for this issue in the long-term (or at all), nor am I sure what a good solution otherwise would be, but as far as I've tested, it seems to work consistently. Personally, I feel that in lieu of refactoring this situation out of this class, this is a good enough solution; if Roblox ever changes this behavior in the future, it will either break again in the same way it was broken, or behavior will not change except for these variables to be made unnecessary.